### PR TITLE
Fix Core Widget Fields Not Rendering "0" Value

### DIFF
--- a/src/wp-includes/widgets/class-wp-nav-menu-widget.php
+++ b/src/wp-includes/widgets/class-wp-nav-menu-widget.php
@@ -48,14 +48,18 @@ class WP_Nav_Menu_Widget extends WP_Widget {
 		}
 
 		$default_title = __( 'Menu' );
-		$title         = ! empty( $instance['title'] ) ? $instance['title'] : '';
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = $default_title;
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
 		echo $args['before_widget'];
 
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 
@@ -123,7 +127,7 @@ class WP_Nav_Menu_Widget extends WP_Widget {
 	 */
 	public function update( $new_instance, $old_instance ) {
 		$instance = array();
-		if ( ! empty( $new_instance['title'] ) ) {
+		if ( isset( $new_instance['title'] ) && '' !== $new_instance['title'] ) {
 			$instance['title'] = sanitize_text_field( $new_instance['title'] );
 		}
 		if ( ! empty( $new_instance['nav_menu'] ) ) {

--- a/src/wp-includes/widgets/class-wp-widget-archives.php
+++ b/src/wp-includes/widgets/class-wp-widget-archives.php
@@ -42,7 +42,11 @@ class WP_Widget_Archives extends WP_Widget {
 	 */
 	public function widget( $args, $instance ) {
 		$default_title = __( 'Archives' );
-		$title         = ! empty( $instance['title'] ) ? $instance['title'] : $default_title;
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = $default_title;
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
@@ -52,7 +56,7 @@ class WP_Widget_Archives extends WP_Widget {
 
 		echo $args['before_widget'];
 
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 

--- a/src/wp-includes/widgets/class-wp-widget-calendar.php
+++ b/src/wp-includes/widgets/class-wp-widget-calendar.php
@@ -48,13 +48,17 @@ class WP_Widget_Calendar extends WP_Widget {
 	 * @param array $instance The settings for the particular instance of the widget.
 	 */
 	public function widget( $args, $instance ) {
-		$title = ! empty( $instance['title'] ) ? $instance['title'] : '';
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = '';
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
 		echo $args['before_widget'];
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 		if ( 0 === self::$instance ) {

--- a/src/wp-includes/widgets/class-wp-widget-categories.php
+++ b/src/wp-includes/widgets/class-wp-widget-categories.php
@@ -46,7 +46,11 @@ class WP_Widget_Categories extends WP_Widget {
 		static $first_dropdown = true;
 
 		$default_title = __( 'Categories' );
-		$title         = ! empty( $instance['title'] ) ? $instance['title'] : $default_title;
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = $default_title;
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
@@ -57,7 +61,7 @@ class WP_Widget_Categories extends WP_Widget {
 
 		echo $args['before_widget'];
 
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 

--- a/src/wp-includes/widgets/class-wp-widget-meta.php
+++ b/src/wp-includes/widgets/class-wp-widget-meta.php
@@ -44,14 +44,18 @@ class WP_Widget_Meta extends WP_Widget {
 	 */
 	public function widget( $args, $instance ) {
 		$default_title = __( 'Meta' );
-		$title         = ! empty( $instance['title'] ) ? $instance['title'] : $default_title;
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = $default_title;
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
 		echo $args['before_widget'];
 
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 

--- a/src/wp-includes/widgets/class-wp-widget-pages.php
+++ b/src/wp-includes/widgets/class-wp-widget-pages.php
@@ -42,7 +42,11 @@ class WP_Widget_Pages extends WP_Widget {
 	 */
 	public function widget( $args, $instance ) {
 		$default_title = __( 'Pages' );
-		$title         = ! empty( $instance['title'] ) ? $instance['title'] : $default_title;
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = $default_title;
+		}
 
 		/**
 		 * Filters the widget title.
@@ -88,7 +92,7 @@ class WP_Widget_Pages extends WP_Widget {
 
 		if ( ! empty( $output ) ) {
 			echo $args['before_widget'];
-			if ( $title ) {
+			if ( '' !== $title ) {
 				echo $args['before_title'] . $title . $args['after_title'];
 			}
 

--- a/src/wp-includes/widgets/class-wp-widget-recent-comments.php
+++ b/src/wp-includes/widgets/class-wp-widget-recent-comments.php
@@ -84,7 +84,11 @@ class WP_Widget_Recent_Comments extends WP_Widget {
 		$output = '';
 
 		$default_title = __( 'Recent Comments' );
-		$title         = ( ! empty( $instance['title'] ) ) ? $instance['title'] : $default_title;
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = $default_title;
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
@@ -118,7 +122,7 @@ class WP_Widget_Recent_Comments extends WP_Widget {
 		);
 
 		$output .= $args['before_widget'];
-		if ( $title ) {
+		if ( '' !== $title ) {
 			$output .= $args['before_title'] . $title . $args['after_title'];
 		}
 

--- a/src/wp-includes/widgets/class-wp-widget-recent-posts.php
+++ b/src/wp-includes/widgets/class-wp-widget-recent-posts.php
@@ -47,7 +47,11 @@ class WP_Widget_Recent_Posts extends WP_Widget {
 		}
 
 		$default_title = __( 'Recent Posts' );
-		$title         = ( ! empty( $instance['title'] ) ) ? $instance['title'] : $default_title;
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = $default_title;
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
@@ -90,7 +94,7 @@ class WP_Widget_Recent_Posts extends WP_Widget {
 		<?php echo $args['before_widget']; ?>
 
 		<?php
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 
@@ -111,7 +115,11 @@ class WP_Widget_Recent_Posts extends WP_Widget {
 			<?php foreach ( $r->posts as $recent_post ) : ?>
 				<?php
 				$post_title   = get_the_title( $recent_post->ID );
-				$title        = ( ! empty( $post_title ) ) ? $post_title : __( '(no title)' );
+				if ( isset( $post_title ) && '' !== $post_title ) {
+					$title = $post_title;
+				} else {
+					$title = __( '(no title)' );
+				}
 				$aria_current = '';
 
 				if ( get_queried_object_id() === $recent_post->ID ) {

--- a/src/wp-includes/widgets/class-wp-widget-rss.php
+++ b/src/wp-includes/widgets/class-wp-widget-rss.php
@@ -64,13 +64,17 @@ class WP_Widget_RSS extends WP_Widget {
 		}
 
 		$rss   = fetch_feed( $url );
-		$title = $instance['title'];
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = '';
+		}
 		$desc  = '';
 		$link  = '';
 
 		if ( ! is_wp_error( $rss ) ) {
 			$desc = esc_attr( strip_tags( html_entity_decode( $rss->get_description(), ENT_QUOTES, get_option( 'blog_charset' ) ) ) );
-			if ( empty( $title ) ) {
+			if ( '' === $title ) {
 				$title = strip_tags( $rss->get_title() );
 			}
 			$link = strip_tags( $rss->get_permalink() );
@@ -79,14 +83,14 @@ class WP_Widget_RSS extends WP_Widget {
 			}
 		}
 
-		if ( empty( $title ) ) {
+		if ( '' === $title ) {
 			$title = ! empty( $desc ) ? $desc : __( 'Unknown Feed' );
 		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
-		if ( $title ) {
+		if ( '' !== $title ) {
 			$feed_link = '';
 			$feed_url  = strip_tags( $url );
 			$feed_icon = includes_url( 'images/rss.png' );
@@ -114,7 +118,7 @@ class WP_Widget_RSS extends WP_Widget {
 		}
 
 		echo $args['before_widget'];
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 

--- a/src/wp-includes/widgets/class-wp-widget-search.php
+++ b/src/wp-includes/widgets/class-wp-widget-search.php
@@ -41,13 +41,17 @@ class WP_Widget_Search extends WP_Widget {
 	 * @param array $instance Settings for the current Search widget instance.
 	 */
 	public function widget( $args, $instance ) {
-		$title = ! empty( $instance['title'] ) ? $instance['title'] : '';
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = '';
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
 		echo $args['before_widget'];
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 

--- a/src/wp-includes/widgets/class-wp-widget-tag-cloud.php
+++ b/src/wp-includes/widgets/class-wp-widget-tag-cloud.php
@@ -42,7 +42,7 @@ class WP_Widget_Tag_Cloud extends WP_Widget {
 	public function widget( $args, $instance ) {
 		$current_taxonomy = $this->_get_current_taxonomy( $instance );
 
-		if ( ! empty( $instance['title'] ) ) {
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
 			$title = $instance['title'];
 		} else {
 			if ( 'post_tag' === $current_taxonomy ) {
@@ -89,7 +89,7 @@ class WP_Widget_Tag_Cloud extends WP_Widget {
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
 		echo $args['before_widget'];
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 
@@ -144,7 +144,11 @@ class WP_Widget_Tag_Cloud extends WP_Widget {
 	 * @param array $instance Current settings.
 	 */
 	public function form( $instance ) {
-		$title = ! empty( $instance['title'] ) ? $instance['title'] : '';
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = '';
+		}
 		$count = isset( $instance['count'] ) ? (bool) $instance['count'] : false;
 		?>
 		<p>

--- a/src/wp-includes/widgets/class-wp-widget-text.php
+++ b/src/wp-includes/widgets/class-wp-widget-text.php
@@ -227,12 +227,16 @@ class WP_Widget_Text extends WP_Widget {
 	public function widget( $args, $instance ) {
 		global $post;
 
-		$title = ! empty( $instance['title'] ) ? $instance['title'] : '';
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = '';
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
-		$text                  = ! empty( $instance['text'] ) ? $instance['text'] : '';
+		$text                  = isset( $instance['text'] ) && '' !== $instance['text'] ? $instance['text'] : '';
 		$is_visual_text_widget = ( ! empty( $instance['visual'] ) && ! empty( $instance['filter'] ) );
 
 		// In 4.8.0 only, visual Text widgets get filter=content, without visual prop; upgrade instance props just-in-time.
@@ -328,7 +332,7 @@ class WP_Widget_Text extends WP_Widget {
 		}
 
 		echo $args['before_widget'];
-		if ( ! empty( $title ) ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/38133

## Description
This PR fixes an issue where core widget fields fail to render when the value is "0". The problem occurs because `empty()` checks in widget fields treat "0" as an empty value, causing widgets to not display content when "0" is the only value.

## Problem
Currently, if you set a single "0" as the value in many default widgets (e.g., widget title or content), it won't output anything due to the use of `empty()` checks. The issue arises because `empty()` returns `TRUE` for "0" values, treating them as empty.

For example:
- Setting a widget title to "0" results in no title being displayed
- Multiple zeros ("00") or other values work correctly
- This affects multiple default widgets where `empty()` is used for validation

## Solution
Replace `empty()` checks with explicit `isset()` and string comparison:
```php
// Before
if ( ! empty( $instance['title'] ) ) {
    $title = $instance['title'];
}

// After
if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
    $title = $instance['title'];
}